### PR TITLE
Support for running tests for a single exercise, colors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,9 @@ bin/configlet.exe
 **/npm-debug.log
 
 # Purescript artifact directories
-**/bower_components/
+**/bower_components
 **/node_modules/
 **/.pulp-cache/
-**/output/
+**/output
 **/.psc*
 **/.psa*

--- a/bin/test-one.sh
+++ b/bin/test-one.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+exercise_dir="$1"
+if [[ -z "$exercise_dir" ]]; then
+  echo "Usage: $BASH_SOURCE <exercise>" 
+  exit 1
+fi
+
+xpurescript=$(dirname "$BASH_SOURCE")
+xpurescript=$(readlink -f "$xpurescript/..")
+cd "$xpurescript"
+
+cache_dir="$HOME"
+if [ -z "$TRAVIS" ]; then
+  cache_dir="$xpurescript"
+fi
+cache_dir="$cache_dir/.exercise_cache"
+
+declare -i TEST_RESULT=0
+
+echo
+echo -e "\e[1;34m----- Testing exercise \e[33m$exercise_dir\e[34m -----\e[0;39m"
+echo
+
+if [[ ! -f "exercises/$exercise_dir/bower.json" ]]; then
+  echo -e "\e[1;31mExercise \e[33m$exercise_dir\e[31m is missing bower.json, failing test\e[0;39m"
+  exit 1
+fi
+
+cd "exercises/$exercise_dir"
+
+exercise_src=src
+exercise_examples_src=examples/src
+
+# Setup Travis cache
+for dir in bower_components output; do
+  cache="$cache_dir/$exercise_dir/$dir"
+
+  mkdir -p "$cache"
+  ln -f -s "$cache"
+done
+
+mv "$exercise_src" "$exercise_src.impl"
+mv "$exercise_examples_src" "$exercise_src"
+
+bower install
+pulp test
+
+# capture result from last command (pulp test)
+if [[ $? == 0 ]]; then
+  TEST_RESULT=1
+fi
+
+# be kind, rewind
+mv "$exercise_src" "$exercise_examples_src"
+mv "$exercise_src.impl" "$exercise_src"
+
+exit $TEST_RESULT

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -1,18 +1,8 @@
 #!/usr/bin/env bash
 
-# TEST
-
 xpurescript=$(dirname "$BASH_SOURCE")
 xpurescript=$(readlink -f "$xpurescript/..")
 cd "$xpurescript"
-echo "xpurescript: $xpurescript"
-
-cache_dir="$HOME"
-if [ -z "$TRAVIS" ]; then
-  cache_dir="$xpurescript"
-fi
-cache_dir="$cache_dir/.exercise_cache"
-echo "cache_dir: $cache_dir"
 
 declare -i TEST_RESULT=0
 FAILED_EXERCISES=''
@@ -21,44 +11,23 @@ cd exercises
 
 for exercise_dir in *
 do
-  echo "-------------------------------------------------------"
-  echo "Testing $exercise_dir"
+  "$xpurescript/bin/test-one.sh" "$exercise_dir"
 
-  cd "$exercise_dir"
-
-  exercise_src=src
-  exercise_examples_src=examples/src
-
-  # Setup Travis cache
-  for dir in bower_components output; do
-    cache="$cache_dir/$exercise_dir/$dir"
-
-    mkdir -p "$cache"
-    ln -f -s "$cache"
-    echo "cache: $(ls -l "$dir")"
-  done
-
-  mv "$exercise_src" "$exercise_src.impl"
-  mv "$exercise_examples_src" "$exercise_src"
-
-  bower install
-  pulp test
-
-  # capture result from last command (pulp test)
-  if [ $? -ne 0 ]; then
-      TEST_RESULT=1
-      FAILED_EXERCISES+="$exercise_dir\n"
+  if [[ $? == 0 ]]; then
+    TEST_RESULT=1
+    FAILED_EXERCISES+="$exercise_dir\n"
   fi
-
-  # be kind, rewind
-  mv "$exercise_src" "$exercise_examples_src"
-  mv "$exercise_src.impl" "$exercise_src"
-
-  cd -
 done
 
-if [ $TEST_RESULT -ne 0 ]; then
-  echo "The following exercises failed"
+echo
+if [[ $TEST_RESULT == 0 ]]; then
+  echo -e "\e[1;32mAll exercises passed\e[0;39m"
+else
+  echo -e "\e[1;31mThe following exercises failed"
+
+  echo -e "\e[1;33m"
   printf $FAILED_EXERCISES
+  echo -e "\e[0;39m"
+
   exit $TEST_RESULT
 fi


### PR DESCRIPTION
Split test script into two parts:

- Running all exercises (the one we had before, used by Travis)
- Running a single exercise (saves time when testing a single exercise)

Also added some colors to the build log, a bit easier to spot specific exercises this way.

Example build: https://travis-ci.org/icyrockcom/xpurescript/builds/214856188

Let me know what you guys think.