### PR TITLE
Fail Travis build fast if previous step failed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,7 @@ install:
   - nvm use 6
   - npm install -g purescript@0.10.2 pulp bower
 
-script:
-  - bin/fetch-configlet
-  - bin/configlet .
-  - bin/test.sh
+script: bin/fetch-configlet && bin/configlet . && bin/test.sh
 
 cache:
   directories:


### PR DESCRIPTION
Builds that have incorrect `config.json` fail in the second (execute `bin/configlet .`) script, but still needlessly go through all the unit tests (third script, `bin/test.sh`), only to fail at the end because the second script failed.

This PR is an update to fail fast, i.e. the first failing script would fail the whole build.

* Current situation
** Successful build https://travis-ci.org/icyrockcom/xpurescript/builds/219497200
** Failed build https://travis-ci.org/icyrockcom/xpurescript/builds/219544300

* After this PR
** Successful build https://travis-ci.org/icyrockcom/xpurescript/builds/219902724
** Failed build https://travis-ci.org/icyrockcom/xpurescript/builds/219902353

